### PR TITLE
fix: point contract verification at live explorer API hosts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,9 +4,9 @@ OWNER_ADDRESS=0x7B7df6b9f9836Bc4dxxxxxxx
 
 #networks
 VANA_RPC_URL=http://rpc.vana.org
-VANA_API_URL=https://api.vanascan.io/api
+VANA_API_URL=https://vanascan.io/api
 VANA_BROWSER_URL=https://vanascan.io
 
 MOKSHA_RPC_URL=https://rpc.moksha.vana.org
-MOKSHA_API_URL=https://rpc.moksha.vana.org/api
+MOKSHA_API_URL=https://moksha.vanascan.io/api
 MOKSHA_BROWSER_URL=https://moksha.vanascan.io


### PR DESCRIPTION
## Problem

Contract verification is broken with the checked-in example env, on both networks.

| URL in .env.example | Result |
| --- | --- |
| `https://api.vanascan.io/api` | HTTP 522, Cloudflare cannot reach origin |
| `https://rpc.moksha.vana.org/api` | HTTP 404, wrong host, that is the RPC node not the explorer |

`api.vanascan.io`, `api.moksha.vanascan.io` and `api.satori.vanascan.io` are all dead. The DNS records exist and are proxied through Cloudflare, but the origin behind them no longer answers.

## Fix

Point both at the hosts that actually serve the Blockscout v1 API:

| URL | Result |
| --- | --- |
| `https://vanascan.io/api` | HTTP 200 |
| `https://moksha.vanascan.io/api` | HTTP 200 |

Verified with the same call hardhat verify makes:

```
curl "https://vanascan.io/api?module=contract&action=getsourcecode&address=0x0000000000000000000000000000000000000000"
{"message":"OK","result":[{"Address":"0x0000000000000000000000000000000000000000"}],"status":"1"}
```

This is what `vana-smart-contracts` already uses, so this only brings these repos in line.

## Note

`SATORI_API_URL` is left untouched. Satori is retired and `satori.vanascan.io` no longer serves the API either, so there is no working value to point it at.
